### PR TITLE
[COOK-4402] Fedoras >= 20 have $releasever in their gpg keys.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ provisioner:
 
 platforms:
   - name: fedora-19
+  - name: fedora-20
 
 suites:
   - name: default

--- a/attributes/fedora-debuginfo.rb
+++ b/attributes/fedora-debuginfo.rb
@@ -5,4 +5,8 @@ default['yum']['fedora-debuginfo']['enabled'] = false
 default['yum']['fedora-debuginfo']['managed'] = false
 default['yum']['fedora-debuginfo']['metadata_expire'] = '7d'
 default['yum']['fedora-debuginfo']['gpgcheck'] = true
-default['yum']['fedora-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['fedora-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['fedora-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/fedora-source.rb
+++ b/attributes/fedora-source.rb
@@ -5,4 +5,8 @@ default['yum']['fedora-source']['enabled'] = false
 default['yum']['fedora-source']['managed'] = false
 default['yum']['fedora-source']['metadata_expire'] = '7d'
 default['yum']['fedora-source']['gpgcheck'] = true
-default['yum']['fedora-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['fedora-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['fedora-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/fedora.rb
+++ b/attributes/fedora.rb
@@ -5,4 +5,8 @@ default['yum']['fedora']['enabled'] = true
 default['yum']['fedora']['managed'] = true
 default['yum']['fedora']['metadata_expire'] = '7d'
 default['yum']['fedora']['gpgcheck'] = true
-default['yum']['fedora']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['fedora']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['fedora']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/updates-debuginfo.rb
+++ b/attributes/updates-debuginfo.rb
@@ -4,4 +4,8 @@ default['yum']['updates-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproje
 default['yum']['updates-debuginfo']['enabled'] = false
 default['yum']['updates-debuginfo']['managed'] = false
 default['yum']['updates-debuginfo']['gpgcheck'] = true
-default['yum']['updates-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['updates-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['updates-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/updates-source.rb
+++ b/attributes/updates-source.rb
@@ -4,4 +4,8 @@ default['yum']['updates-source']['mirrorlist'] = 'https://mirrors.fedoraproject.
 default['yum']['updates-source']['enabled'] = false
 default['yum']['updates-source']['managed'] = false
 default['yum']['updates-source']['gpgcheck'] = true
-default['yum']['updates-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['updates-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['updates-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/updates-testing-debuginfo.rb
+++ b/attributes/updates-testing-debuginfo.rb
@@ -4,4 +4,8 @@ default['yum']['updates-testing-debuginfo']['mirrorlist'] = 'https://mirrors.fed
 default['yum']['updates-testing-debuginfo']['enabled'] = false
 default['yum']['updates-testing-debuginfo']['managed'] = false
 default['yum']['updates-testing-debuginfo']['gpgcheck'] = true
-default['yum']['updates-testing-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['updates-testing-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['updates-testing-debuginfo']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/updates-testing-source.rb
+++ b/attributes/updates-testing-source.rb
@@ -4,4 +4,8 @@ default['yum']['updates-testing-source']['mirrorlist'] = 'https://mirrors.fedora
 default['yum']['updates-testing-source']['enabled'] = false
 default['yum']['updates-testing-source']['managed'] = false
 default['yum']['updates-testing-source']['gpgcheck'] = true
-default['yum']['updates-testing-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['updates-testing-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['updates-testing-source']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/updates-testing.rb
+++ b/attributes/updates-testing.rb
@@ -4,4 +4,8 @@ default['yum']['updates-testing']['mirrorlist'] = 'https://mirrors.fedoraproject
 default['yum']['updates-testing']['enabled'] = false
 default['yum']['updates-testing']['managed'] = false
 default['yum']['updates-testing']['gpgcheck'] = true
-default['yum']['updates-testing']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['updates-testing']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['updates-testing']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end

--- a/attributes/updates.rb
+++ b/attributes/updates.rb
@@ -4,4 +4,8 @@ default['yum']['updates']['mirrorlist'] = 'https://mirrors.fedoraproject.org/met
 default['yum']['updates']['enabled'] = true
 default['yum']['updates']['managed'] = true
 default['yum']['updates']['gpgcheck'] = true
-default['yum']['updates']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+if node['platform_version'].to_i < 20
+  default['yum']['updates']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$basearch'
+else
+  default['yum']['updates']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch'
+end


### PR DESCRIPTION
Also add fedora-20 to the test-kitchen, so we catch things like this earlier.
