### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
       actions: write
       checks: write
@@ -34,7 +34,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Cinc Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@9.0.0
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,13 +36,11 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/
 .coverage/
 .zero-knife.rb
-Policyfile.lock.json
 
 # vagrant stuff
 .vagrant/

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,91 @@
+{
+  "revision_id": "096921f1151a93c31290bc8c9ce85a375a2e2aaccda1ae03edbb11c6224c1f1d",
+  "name": "yum-fedora",
+  "run_list": [
+    "recipe[test::default]"
+  ],
+  "named_run_lists": {
+    "default": [
+      "recipe[test::default]"
+    ],
+    "enable_all": [
+      "recipe[test::enable_all]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "test": {
+      "version": "0.1.0",
+      "identifier": "1165035aa010a53416aaa6c92ab0b07bce03d431",
+      "dotted_decimal_identifier": "4896139683827877.14661620987407024.194045783823409",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": "git@github.com:sous-chefs/yum-fedora.git",
+        "revision": "3a7f1763e91b04050d86a8d6367f13b74ee86b7b",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    },
+    "yum-fedora": {
+      "version": "4.0.0",
+      "identifier": "45683ebdaf80392f040c61aef35daf9c732a840e",
+      "dotted_decimal_identifier": "19536392072691769.13233775130375005.193086481925134",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": "git@github.com:sous-chefs/yum-fedora.git",
+        "revision": "3a7f1763e91b04050d86a8d6367f13b74ee86b7b",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "test",
+        ">= 0.0.0"
+      ],
+      [
+        "yum-fedora",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "test (0.1.0)": [
+        [
+          "yum-fedora",
+          ">= 0.0.0"
+        ]
+      ],
+      "yum-fedora (4.0.0)": [
+
+      ]
+    }
+  }
+}

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+name 'yum-fedora'
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'yum-fedora', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+named_run_list :default, 'test::default'
+named_run_list :enable_all, 'test::enable_all'

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -8,6 +8,7 @@ transport: { name: dokken }
 
 provisioner:
   name: dokken
+  policyfile_path: Policyfile.rb
   multiple_converge: 2
   enforce_idempotency: true
 

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,7 @@
 ---
 provisioner:
   name: chef_infra
+  policyfile_path: Policyfile.rb
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 
 provisioner:
   name: chef_infra
+  policyfile_path: Policyfile.rb
   product_name: chef
   product_version: latest
   channel: stable
@@ -19,12 +20,6 @@ verifier:
 platforms:
   - name: fedora-latest
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-  enable_all: &enable_all_run_list
-    - recipe[test::enable_all]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -35,9 +30,11 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
 
   - name: enable-all
-    run_list: *enable_all_run_list
+    provisioner:
+      named_run_list: enable_all
     verifier: *enable_all_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- replace Berkshelf with Policyfile/Policyfile.lock.json
- switch ChefSpec and Kitchen to Policyfile resolution and named run lists
- update CI setup away from berks install and pin lint-unit/install-workstation to 9.0.0

## Validation
- chef install Policyfile.rb
- cookstyle
- chef exec rspec (blocked by macOS code-signing on user gem json extension)
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- markdownlint-cli2
- yamllint .
- actionlint
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- env DOCKER_HOST=unix:///Users/damacus/.docker/run/docker.sock KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose
- env DOCKER_HOST=unix:///Users/damacus/.docker/run/docker.sock KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-fedora-latest --destroy=always